### PR TITLE
Adds mono audio option matching the PCB's JAMMA mono output

### DIFF
--- a/Salamander.sv
+++ b/Salamander.sv
@@ -216,7 +216,7 @@ pll pll(
 // 0         1         2         3          4         5         6   
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// X  XXX X  X            X
+// X  XXX X  XX           X
 
 wire    [127:0] status; //status bits
 
@@ -230,6 +230,11 @@ localparam CONF_STR = {
 
     "P1OA,VGA Scaler,off,on;",
     "P1O35,Scandoubler Fx,None,HQ2x,CRT 25%,CRT 50%,CRT 75%;",
+
+	"-;",
+    "P2,Audio;",
+    "P2-;",
+    "P2OB,Jamma mono out,off,on;",
 
     "-;",
     "DIP;",
@@ -305,7 +310,7 @@ wire            master_reset = RESET | status[0] | buttons[1];
 wire            flip = status[23];
 
 assign          AUDIO_S = 1'b1;
-assign          AUDIO_MIX = 2'd0;
+assign          AUDIO_MIX = status[11] ? 2'd3 : 2'd0;
 
 Salamander_emu gameboard_top (
     .i_EMU_MCLK                 (CLK72M                     ),


### PR DESCRIPTION
The PCB has two Connectors CN2 STEREO and CN3 MONO. The mono out goes through the JAMMA connector on Pin 10 whilst the Stereo out has its own connector (CN5) for use in the dedicated Cabinet. This additional option uses Misters AUDIO_MIX to blend L & R channels to Mono.