### PR TITLE
Ship Selector for Player 1

### DIFF
--- a/Salamander.sv
+++ b/Salamander.sv
@@ -224,6 +224,8 @@ wire    [127:0] status; //status bits
 localparam CONF_STR = {
     "Salamander;",
     "-;",
+	"O9,Player 1 Ship,Vic Viper,Lord British;",
+    "-;",
     "P1,Scaler Settings;",
     "P1-;",
     "P1O7,Aspect ratio,original,full screen;",
@@ -306,6 +308,13 @@ wire            flip = status[23];
 
 assign          AUDIO_S = 1'b1;
 assign          AUDIO_MIX = 2'd0;
+wire            ship_sides_swap = status[9];
+
+// Left controller always = i_JOYSTICK0 = whichever ship the menu currently
+// has assigned to the Left side; Right controller always = i_JOYSTICK1.
+// Default (ship_sides_swap=0): Left=Vic Viper, Right=Lord British.
+wire    [15:0]  joystick_left  = ship_sides_swap ? joystick_1 : joystick_0;
+wire    [15:0]  joystick_right = ship_sides_swap ? joystick_0 : joystick_1;
 
 Salamander_emu gameboard_top (
     .i_EMU_MCLK                 (CLK72M                     ),
@@ -327,9 +336,9 @@ Salamander_emu gameboard_top (
     .o_SND_L                    (AUDIO_L                    ),
     .o_SND_R                    (AUDIO_R                    ),
 
-    .i_JOYSTICK0                (joystick_0                 ),
-    .i_JOYSTICK1                (joystick_1                 ),
-
+    .i_JOYSTICK0                (joystick_left              ),
+    .i_JOYSTICK1                (joystick_right             ),
+	
     .ioctl_index                (ioctl_index                ),
     .ioctl_download             (ioctl_download             ),
     .ioctl_addr                 (ioctl_addr                 ),

--- a/rtl/Salamander_emu.v
+++ b/rtl/Salamander_emu.v
@@ -427,8 +427,17 @@ jtframe_rom_2slots #(
 wire    [7:0]   IN0, IN1, IN2;
 
 //System control
-assign          IN0[0]  = i_JOYSTICK0[5]; //p1 coin
-assign          IN0[1]  = i_JOYSTICK1[5]; //p2 coin
+// DIPSW2[2]: 1 = 1 coin slot, 0 = 2 coin slots.
+// Real 1-slot cabinets have only one coin mech, wired to the P1 coin input;
+// P2's coin input simply doesn't exist on that cabinet wiring. On MiSTer
+// both players have their own pad, so in 1-slot mode let either player's
+// coin button register, instead of only whichever pad happens to be mapped
+// to the P1 connector. 2-slot mode is untouched - each coin input stays
+// independent, exactly as before.
+wire            coin_in_1slot = i_JOYSTICK0[5] | i_JOYSTICK1[5];
+
+assign          IN0[0]  = DIPSW2[2] ? coin_in_1slot : i_JOYSTICK0[5]; //p1/shared coin
+assign          IN0[1]  = i_JOYSTICK1[5]; //p2 coin (only read by the game in 2-slot mode)
 assign          IN0[2]  = i_JOYSTICK0[4]; //service
 assign          IN0[3]  = i_JOYSTICK0[6]; //p1 start
 assign          IN0[4]  = i_JOYSTICK1[6]; //p2 start


### PR DESCRIPTION
The original UK arcade cabinet didn't use standard "Player 1" and "Player 2" designations. Instead, players chose between the Left Player (Blue / Vic Viper) or the Right Player (Red / Lord British), allowing for either solo or cooperative play.

Patch Features:

Single-Controller Ship Selection: This patch allows a single joystick (Player 1) to select and play as either Vic Viper or Lord British, eliminating the need for a second controller for a lone player.

It follows cabinet's Dip2 Setting. If set to a Single Coin Slot, selecting Lord British will allow the first controller to credit up (which originally required a second controller). If Dip2 is set to Dual Coin Slots, the game behaves normally, requiring each respective controller to credit up.